### PR TITLE
Change destroy's behavior to return number of rows affected. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ console.log(user.bar); // baz
 The static method `update` accepts new properties and a knex where clause object and returns to you instantiations of your class. It will return an array if there is more than one, otherwise it just give you the model updated. This is usefull if you are updating by ID.
 
 ```javascript
-User.update({ foo: 'baz' }, { id: '123' })
-  .then((user) => {
-    console.log(user.foo); // baz
-  });
-
 User.update({ foo: 'baz' }, { foo: 'bar' })
   .then((users) => {
     console.log(user[0].foo); // baz
@@ -75,7 +70,10 @@ User.update({ foo: 'baz' }, { foo: 'bar' })
 The static method `destroy` accepts a knex where clause object to delete records.
 
 ```javascript
-User.destroy({ foo: 'bar' }); // Deletes all users where foo is bar
+User.destroy({ foo: 'bar' }) // Deletes all users where foo is bar
+  .then((res) => {
+    console.log(res); // 1
+  });
 ```
 
 ### Collection
@@ -117,17 +115,26 @@ user.save({ method: 'update' }); // performs update
 
 ### Destroy
 
-When deleting, it assumes you want to delete by `id` unless you provide an id object that is in the format of a knex where object.
+When deleting, it assumes you want to delete by `id` unless you previously have set keys on the static model. These keys, if present, will be used to uniquely identify the model for deletion.
 
 ```javascript
 User.fetch({ id: '123' })
-  .then((user) => {
-    return user.destroy();
+  .then((user) => user.destroy())
+  .then((res) => {
+    console.log(res); // 1
   });
 
 User.fetch({ id: '123' })
-  .then((user) => {
-    return user.destroy({ foo: 'bar', bar: 'baz' });
+  .then((user) => user.destroy())
+  .then((res) => {
+    console.log(res); // 1
+  });
+
+User.keys = [ 'foo' ];
+User.fetch({ foo: 'bar' })
+  .then((user) => user.destroy())
+  .then((res) => {
+    console.log(res); // 1
   });
 ```
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -53,6 +53,28 @@ class Base {
   }
 
   /**
+   * Get the primary or compound keys used to uniquely identify a model.
+   *
+   * @returns {array} The columns used to uniquely identify a model.
+   */
+  static get keys() {
+    if (!this._keys) {
+      this._keys = [];
+    }
+
+    return this._keys;
+  }
+
+  /**
+   * Set the primary or compound keys used to uniquely identify a model.
+   *
+   * @param {array} k The columns used to uniquely identify a model.
+   */
+  static set keys(k) {
+    this._keys = k;
+  }
+
+  /**
    * Forges a model but does not insert. Calls the constructor under the hood.
    *
    * @param {Object} properties The Model properties.
@@ -121,7 +143,7 @@ class Base {
    *
    * @param {Object} where Where clause for updating.
    * @param {Object} opts Options for saving.
-   * @return {Promise} A knex promise.
+   * @return {Promise} A knex promise yielding rows affected.
    */
   static destroy(where = {}, opts = {}) {
     const knex = Util.assertKnex(opts.trx || opts.knex || Config.knex);
@@ -200,16 +222,22 @@ class Base {
    * Delete the model.
    *
    * @param {Object} opts Options for saving.
-   * @returns {*} The deleted model.
+   * @return {Promise} A knex promise yielding rows affected.
    */
   destroy(opts = {}) {
     const knex = Util.assertKnex(opts.trx || opts.knex || this._trx || Config.knex);
-    const id = opts.id || { id: this.id };
+    let where = { id: this.id };
+
+    // Custom primary or compound keys
+    if (this.constructor.keys.length) {
+      where = transform(this.constructor.keys, (a, v) => {
+        a[snakeCase(v)] = this[v];
+      }, {});
+    }
 
     return knex(this.constructor.table)
       .del()
-      .where(id)
-      .return(this);
+      .where(where);
   }
 
   transaction(trx) {

--- a/test/base_tests.js
+++ b/test/base_tests.js
@@ -15,6 +15,8 @@ describe('Base', () => {
 
   beforeEach(() => {
     Base.knex = null;
+    delete Model._keys;
+
     return Utils.clear(knex);
   });
 
@@ -474,10 +476,16 @@ describe('Base', () => {
 
     describe('destroy', () => {
       it('should delete a model', () => {
+        let model;
+
         return Model.create(properties, { knex })
-          .then((model) => model.destroy())
-          .then((model) => {
-            expect(model).to.be.instanceOf(Model);
+          .then((m) => {
+            model = m;
+
+            return model.destroy();
+          })
+          .then((res) => {
+            expect(res).to.equal(1);
 
             return knex('models')
               .select()
@@ -489,10 +497,38 @@ describe('Base', () => {
       });
 
       it('should delete a model with provided query', () => {
+        let model;
+
         return Model.create(properties, { knex })
-          .then((model) => model.destroy({ foo: 'bar' }))
-          .then((model) => {
-            expect(model).to.be.instanceOf(Model);
+          .then((m) => {
+            model = m;
+
+            return model.destroy({ foo: 'bar' });
+          })
+          .then((res) => {
+            expect(res).to.equal(1);
+
+            return knex('models')
+              .select()
+              .where('id', model.id);
+          })
+          .then((res) => {
+            expect(res).to.have.property('length', 0);
+          });
+      });
+
+      it('should delete a model using the model\'s keys', () => {
+        let model;
+        Model.keys = [ 'id' ];
+
+        return Model.create(properties, { knex })
+          .then((m) => {
+            model = m;
+
+            return model.destroy();
+          })
+          .then((res) => {
+            expect(res).to.equal(1);
 
             return knex('models')
               .select()


### PR DESCRIPTION
Add ability to manually set which columns to use to uniquely identify a model.
